### PR TITLE
fix: remove mandatory $self and $base from `IRawRepositoryMap`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 9
+          run_install: false
+
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-      - run: npm ci
-      - run: npm run compile
-      - run: npm test
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run compile
+      - run: pnpm run test

--- a/src/rawGrammar.ts
+++ b/src/rawGrammar.ts
@@ -30,8 +30,6 @@ export type RegExpString = string;
 
 export interface IRawRepositoryMap {
 	[name: string]: IRawRule;
-	$self: IRawRule;
-	$base: IRawRule;
 }
 
 export type IRawRepository = IRawRepositoryMap & ILocatable;


### PR DESCRIPTION
None of the grammars in the `textmate-grammars-themes` package have `$self` and `$base` in their `repository` field, so I assume it's a typing mistake.
